### PR TITLE
[PR] history페이지의 필터버튼 구역 상단 고정시키기

### DIFF
--- a/src/pages/History.jsx
+++ b/src/pages/History.jsx
@@ -60,28 +60,29 @@ const History = () => {
   }, [])
 
   return (
-    <div className='w-full bg-white'>
+    <div className='flex flex-col h-screen'>
       {/* 필터 버튼 UI */}
-      <div className='flex flex-row w-full h-[57px] border-b-[0.7px] border-[#D9D9D9] px-[18px] gap-[5px]'>
+      <div className='shrink-0 flex flex-row w-full h-[57px] border-b-[0.7px] border-[#D9D9D9] px-[18px] gap-[5px]'>
         <FilterButtons />
       </div>
+      <div className='w-full bg-white flex-1 overflow-y-auto'>
+        {/* 카드 리스트 */}
+        {list.map((item, index) => (
+          <HistoryCard
+            key={index}
+            title={item.title}
+            date={item.date}
+            text={item.text}
+            items={item.items}
+          />
+        ))}
 
-      {/* 카드 리스트 */}
-      {list.map((item, index) => (
-        <HistoryCard
-          key={index}
-          title={item.title}
-          date={item.date}
-          text={item.text}
-          items={item.items}
-        />
-      ))}
-
-      {/* 무한 스크롤 감지용 div */}
-      <div
-        ref={loaderRef}
-        className='h-[50px]'
-      ></div>
+        {/* 무한 스크롤 감지용 div */}
+        <div
+          ref={loaderRef}
+          className='h-[50px]'
+        ></div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #73 

## #️⃣ 작업 내용

> history페이지 필터버튼 구역 상단 고정

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 개발한 코드가 목적에 맞게 잘 작동하는지 확인했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)

## #️⃣ 스크린샷 (선택)

> <img width="401" height="803" alt="image" src="https://github.com/user-attachments/assets/27588772-5d19-498e-bc0c-645a5ede51a2" />

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 예시: 이 부분의 코드가 잘 작동하는지 테스트해 주실 수 있나요?

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요