### PR TITLE
fix: 홈페이지 진입 직후 키워드 학습 시도시 키워드 설명 본문 불러와지지 않는 오류 수정

### DIFF
--- a/src/components/MissionCard.jsx
+++ b/src/components/MissionCard.jsx
@@ -113,11 +113,21 @@ const MissionCard = ({ mission }) => {
   }
 
   const handleQuizStart = () => {
-    // 현재 미션에서 날짜를 선택하지 않았으면 기본 dailyContentId 설정
-    if (!selectedDateInfo) {
+    // selectedDateInfo가 있으면 해당 날짜의 dailyContentId 설정
+    if (selectedDateInfo && selectedDateInfo.date) {
+      const dateItem = mission.dateList?.find(
+        (item) => item.date === selectedDateInfo.date,
+      )
+      if (dateItem?.dailyContentId) {
+        setDailyContentId(dateItem.dailyContentId)
+      } else {
+        // dateList에 없으면 기본 dailyContentId 사용
+        setDailyContentId(mission.dailyContent.dailyContentId)
+      }
+    } else {
+      // selectedDateInfo가 없으면 기본 dailyContentId 사용
       setDailyContentId(mission.dailyContent.dailyContentId)
     }
-    // selectedDateInfo가 있으면 이미 store에 dailyContentId가 설정되어 있음
     navigate('/quiz/keyword-explain')
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#102 

## #️⃣ 작업 내용

홈페이지 진입 직후 키워드 학습 시도시 키워드 설명 본문 불러와지지 않는 오류 수정

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 개발한 코드가 목적에 맞게 잘 작동하는지 확인했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)