### PR TITLE
[PR] 달력 페이지 및 미션 디테일 페이지 수정

### DIFF
--- a/src/pages/Mission/Details.jsx
+++ b/src/pages/Mission/Details.jsx
@@ -28,7 +28,6 @@ const Details = () => {
   const { id } = useParams()
   const setShowNavigation = useUIOptionStore((state) => state.setShowNavigation)
   const role = useAuthStore((state) => state.role)
-  //const role = 'PARENT' // 테스트용
   const [mission, setMission] = useState(null)
   const [nickname, setNickname] = useState('')
   const [memberId, setMemberId] = useState(null)

--- a/src/pages/Mission/Details.jsx
+++ b/src/pages/Mission/Details.jsx
@@ -263,7 +263,7 @@ const Details = () => {
                 <div className='flex flex-col gap-2 mt-4'>
                   {mission.startDate && (
                     <div className='flex justify-between'>
-                      <span className='text-sm text-gray-600 font-medium'>
+                      <span className='text-sm text-[#404040] font-medium'>
                         시작일
                       </span>
                       <span className='text-sm text-[#404040]'>

--- a/src/pages/Mission/Details.jsx
+++ b/src/pages/Mission/Details.jsx
@@ -114,22 +114,19 @@ const Details = () => {
         status,
       )
     ) {
-      if (role === 'PARENT') {
+      if (role?.toUpperCase() === 'PARENT') {
         // 부모일 때
-        const isRequester = memberId === mission?.requesterId
+        const isRequester = mission?.memberId === mission?.requesterId
         if (isRequester) {
           // 내가 요청자 → 본인 이름
           name = nickname || '멤버'
         } else {
-          // 자녀가 요청자 → requesterId로 자녀 찾기
-          const child = familyMembers.find(
-            (member) => member.memberId === mission.requesterId,
-          )
-          name = child?.nickname || '멤버'
+          // 자녀가 요청자 → requesterNickname 사용
+          name = mission?.requesterNickname || '멤버'
         }
       } else {
         // 자녀일 때
-        const isRequester = memberId === mission?.requesterId
+        const isRequester = mission?.memberId === mission?.requesterId
         if (isRequester) {
           // 내가 요청자 → 본인 이름
           name = nickname || '멤버'
@@ -141,22 +138,17 @@ const Details = () => {
     }
     // 진행/완료 관련 상태: 미션 수행자(자녀)의 이름 표시
     else {
-      if (role === 'PARENT') {
-        // 부모일 때: 누가 요청자인지에 따라 자녀 찾기
-        const isRequester = memberId === mission?.requesterId
+      if (role?.toUpperCase() === 'PARENT') {
+        // 부모일 때: 누가 요청자인지에 따라 자녀(미션 수행자) 찾기
+        // mission.memberId는 API 응답에 포함된 현재 사용자의 ID
+        const isRequester = mission?.memberId === mission?.requesterId
 
-        if (isRequester && mission?.recipientId) {
-          // 내가 자녀에게 미션을 보낸 경우 → recipientId가 자녀
-          const child = familyMembers.find(
-            (member) => member.memberId === mission.recipientId,
-          )
-          name = child?.nickname || '멤버'
-        } else if (!isRequester && mission?.requesterId) {
-          // 자녀가 나에게 미션 승인 요청한 경우 → requesterId가 자녀
-          const child = familyMembers.find(
-            (member) => member.memberId === mission.requesterId,
-          )
-          name = child?.nickname || '멤버'
+        if (isRequester) {
+          // 내가 자녀에게 미션을 보낸 경우 → recipient가 자녀 (미션 수행자)
+          name = mission?.recipientNickname || '멤버'
+        } else {
+          // 자녀가 나에게 미션 승인 요청한 경우 → requester가 자녀 (미션 수행자)
+          name = mission?.requesterNickname || '멤버'
         }
       } else {
         // 자녀일 때: 본인 이름

--- a/src/pages/Mission/Make.jsx
+++ b/src/pages/Mission/Make.jsx
@@ -507,13 +507,14 @@ const Make = () => {
                           <>
                             {/* 시작일 원형 */}
                             <div className='absolute z-10 w-[38px] h-[38px] rounded-full bg-[#5188FB]' />
-                            {/* 시작일 오른쪽 연결 배경 (마지막 열이 아닐 때만) */}
-                            {!isEnd && !isLastColumn && (
+                            {/* 시작일 오른쪽 연결 배경 */}
+                            {!isEnd && (
                               <div
                                 className='absolute h-[38px] bg-[#B2D6FF] z-0'
                                 style={{
                                   left: '19px',
-                                  width: 'calc(100% + 30px)',
+                                  width:
+                                    isLastColumn ? '19px' : 'calc(100% + 30px)',
                                   top: '50%',
                                   transform: 'translateY(-50%)',
                                 }}
@@ -532,7 +533,10 @@ const Make = () => {
                                 className='absolute h-[38px] bg-[#B2D6FF] z-0'
                                 style={{
                                   right: '19px',
-                                  width: 'calc(100% + 30px)',
+                                  width:
+                                    isFirstColumn ? '19px' : (
+                                      'calc(100% + 30px)'
+                                    ),
                                   top: '50%',
                                   transform: 'translateY(-50%)',
                                 }}
@@ -928,8 +932,10 @@ const Make = () => {
           (currentStep === 4 && selectedMembers.length === 0) ||
           (currentStep === 5 && !message.trim() && !noMessage)
         }
-        className={`h-[56px] px-13 py-3 rounded-2xl shadow-lg text-[18px] font-medium transition-all z-50 ${
-          currentStep === 2 ? 'fixed bottom-[46px] left-1/2 -translate-x-1/2 w-[calc(100%-40px)] max-w-[600px]' : 'mx-[20px] mb-[46px]'
+        className={`h-[56px] px-13 py-3 rounded-2xl shadow-lg text-[18px] font-medium z-50 ${
+          currentStep === 2 ?
+            'fixed bottom-[46px] left-1/2 -translate-x-1/2 w-[calc(100%-40px)] max-w-[500px]'
+          : 'mx-[20px] mb-[46px]'
         } ${
           (
             (currentStep === 1 && !selectedMission) ||

--- a/src/pages/Mission/Make.jsx
+++ b/src/pages/Mission/Make.jsx
@@ -926,7 +926,9 @@ const Make = () => {
           (currentStep === 4 && selectedMembers.length === 0) ||
           (currentStep === 5 && !message.trim() && !noMessage)
         }
-        className={`h-[56px] px-13 py-3 mx-[20px] mb-[46px] rounded-2xl shadow-lg text-[18px] font-medium transition-all z-50 ${
+        className={`h-[56px] px-13 py-3 rounded-2xl shadow-lg text-[18px] font-medium transition-all z-50 ${
+          currentStep === 2 ? 'fixed bottom-[46px] left-1/2 -translate-x-1/2 w-[calc(100%-40px)] max-w-[600px]' : 'mx-[20px] mb-[46px]'
+        } ${
           (
             (currentStep === 1 && !selectedMission) ||
             (currentStep === 3 && !reward.trim()) ||

--- a/src/pages/Mission/Make.jsx
+++ b/src/pages/Mission/Make.jsx
@@ -385,7 +385,7 @@ const Make = () => {
       return (
         <div
           key={`${year}-${month}`}
-          className={!isLast ? 'mb-[80px]' : ''}
+          className={`max-w-[310px] mx-auto ${!isLast ? 'mb-[80px]' : ''}`}
         >
           {/* 요일 헤더 (첫 번째 캘린더에만 표시) */}
           {isFirst && (
@@ -580,11 +580,13 @@ const Make = () => {
         {/* 캘린더 컨테이너 - 하나의 박스로 */}
 
         <div
-          className='relative bg-[#E2EFFF] rounded-2xl p-4 overflow-y-auto overflow-x-visible mx-[6px]'
+          className='relative bg-[#E2EFFF] rounded-2xl p-4 overflow-y-auto overflow-x-visible mx-[6px] [&::-webkit-scrollbar]:hidden'
           style={{
             height: '611px',
             touchAction: 'pan-y',
             WebkitOverflowScrolling: 'touch',
+            scrollbarWidth: 'none',
+            msOverflowStyle: 'none',
             maskImage:
               'linear-gradient(to bottom, black 85%, transparent 100%)',
             WebkitMaskImage:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #114 

## #️⃣ 작업 내용

> 
현재 getStatusMessage (최종)

미션 상태 메시지 로직

1. 승인 관련 상태 (APPROVAL_REQUEST, APPROVAL_ACCEPTED, APPROVAL_REJECTED)

표시할 이름: 요청자(requester)

┌─────────────┬───────────────────────────────────┬──────────────────────────┐

│ 현재 사용자 │          누가 요청했나?           │      표시되는 이름       │

├─────────────┼───────────────────────────────────┼──────────────────────────┤

│ 부모        │ 내가 요청 (isRequester = true)    │ 본인 닉네임              │

├─────────────┼───────────────────────────────────┼──────────────────────────┤

│ 부모        │ 자녀가 요청 (isRequester = false) │ requesterNickname (자녀) │

├─────────────┼───────────────────────────────────┼──────────────────────────┤

│ 자녀        │ 내가 요청 (isRequester = true)    │ 본인 닉네임              │

├─────────────┼───────────────────────────────────┼──────────────────────────┤

│ 자녀        │ 부모가 요청 (isRequester = false) │ requesterNickname (부모) │

└─────────────┴───────────────────────────────────┴──────────────────────────┘

<img width="738" height="294" alt="image" src="https://github.com/user-attachments/assets/66d7adf3-4f8d-4bd6-8dd0-9e3640608566" />

- isRequester = mission.memberId === mission.requesterId → 현재 사용자가 요청자인지
판단
- 부모가 미션을 보낸 경우: 자녀는 recipient
- 자녀가 미션 승인을 요청한 경우: 자녀는 requester
- 진행 중 상태에서는 항상 자녀(미션 수행자) 이름이 표시됨


2. Make.jsx의 2페이지 달력 다음버튼 수정
<img width="443" height="843" alt="image" src="https://github.com/user-attachments/assets/5ee9b14d-8418-4b2e-86dd-6e1c3b10ac49" />


## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 개발한 코드가 목적에 맞게 잘 작동하는지 확인했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> Details페이지의 상태에 따른 메세지 변경 중에, 생길 수 있는 오류 있으면 말씀해주시면 감사하겠습니다!

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요