### PR TITLE
[PR] 미션 만들기 페이지 날짜 그리드 수정

### DIFF
--- a/src/pages/Mission/Make.jsx
+++ b/src/pages/Mission/Make.jsx
@@ -425,7 +425,7 @@ const Make = () => {
                 )}
 
                 {/* 날짜 그리드 */}
-                <div className='grid grid-cols-5 gap-x-[30px] gap-y-[14px] px-[1px]'>
+                <div className='grid grid-cols-5 gap-x-[30px] gap-y-[14px] px-[2px]'>
                   {group.days.map((day, index) => {
                     const isStart = isSameDate(day.fullDate, dates.startDate)
                     const isEnd = isSameDate(day.fullDate, dates.endDate)
@@ -486,7 +486,7 @@ const Make = () => {
                       <button
                         key={index}
                         onClick={() => handleDateClick(day.fullDate)}
-                        className='w-[38px] h-[38px] flex items-center justify-center text-sm relative hover:opacity-80 transition-opacity cursor-pointer'
+                        className='w-[38px] h-[38px] flex items-center justify-center text-sm relative hover:opacity-80 transition-opacity cursor-pointer overflow-visible'
                         style={{ gridColumn: gridColumn || 'auto' }}
                       >
                         {/* 1. 범위 내 배경 (연결 바) - 시작일/종료일이 아닐 때만 */}
@@ -584,7 +584,7 @@ const Make = () => {
         {/* 캘린더 컨테이너 - 하나의 박스로 */}
 
         <div
-          className='relative bg-[#E2EFFF] rounded-2xl p-4 overflow-y-auto overflow-x-visible mx-[6px] [&::-webkit-scrollbar]:hidden'
+          className='relative bg-[#E2EFFF] rounded-2xl py-4 px-5 overflow-y-auto overflow-x-visible mx-[6px] [&::-webkit-scrollbar]:hidden'
           style={{
             height: '611px',
             touchAction: 'pan-y',


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #118 

## #️⃣ 작업 내용

> 1. 날짜 그리드 패딩를 px-[2px]로 변경하여 더 많은 여유 공간 확보
  2. 버튼 요소에 날짜 버튼에 overflow-visible 클래스를 추가하여 동그라미 배경이 버튼 
  영역을 벗어나도 잘리지 않도록 설정
  3. 캘린더 컨테이너 또한 패딩 조정 p-4 → py-4 px-5로 변경하여 좌우 여유 공간을 더 확보

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 개발한 코드가 목적에 맞게 잘 작동하는지 확인했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)

## #️⃣ 스크린샷 (선택)

> <img width="624" height="893" alt="image" src="https://github.com/user-attachments/assets/6c1fc724-ff44-4364-a7bc-6c0e93d005ed" />
<img width="600" height="949" alt="image" src="https://github.com/user-attachments/assets/362817a4-45e3-4602-87cb-b6b7674d1c32" />


## #️⃣ 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 
> 우선 웹 화면에서 적용가능한 모바일 기기화면인 iphone SE부터 galaxy s20 울트라까지 테스트를 진행했는데 아직 이상한 점은 발견 못했습니다.( i pad부터는 맞지 않는다고 생각) 그래서 다시 한번 잘리는 이슈 생기면 말씀해주시면 감사하겠습니다!

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요